### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "start"

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ Contributions are very welcome. If you've found a bug create an [issue](https://
 ## Credits
 
 [HackerPoet](https://github.com/HackerPoet "HackerPoet's GitHub profile") better known as CodeParade, for the original implementation. Check out his [YouTube channel](https://www.youtube.com/channel/UCrv269YwJzuZL3dH5PCgxUw "CodeParade's YouTube channel").
+[![Run on Repl.it](https://repl.it/badge/github/fnky/particle-life)](https://repl.it/github/fnky/particle-life)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).